### PR TITLE
refactor: implement modular screen architecture (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ go run main.go
 
 This project is currently in active development. The tournament selection screen is complete, and the Single Elimination tournament implementation is in progress.
 
+**Current Phase:** Phase 2 - Application Structure Refactoring ✅ COMPLETED
+
+See the [Development Plans](./plans/overview.md) for detailed roadmap and progress.
+
+### Project Structure
+```
+go-tournament/
+├── main.go                           # Entry point, screen routing
+├── screen.go                         # Screen state definitions
+├── menu.go                           # Tournament selection menu
+├── tournament/
+│   └── single_elimination.go         # Single elimination (in progress)
+├── plans/                            # Development planning documents
+│   ├── overview.md                   # Project roadmap
+│   ├── phase1-project-setup.md
+│   ├── phase2-app-structure-refactoring.md
+│   └── phase3-participant-setup.md
+├── go.mod
+├── go.sum
+└── README.md
+```
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit issues and enhancement requests.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ This project is currently in active development. The tournament selection screen
 See the [Development Plans](./plans/overview.md) for detailed roadmap and progress.
 
 ### Project Structure
-```
+
+```text
 go-tournament/
 ├── main.go                           # Entry point, screen routing
 ├── screen.go                         # Screen state definitions

--- a/main.go
+++ b/main.go
@@ -28,6 +28,19 @@ func (m model) Init() tea.Cmd {
 	return nil
 }
 
+// switchScreen changes the current screen and injects window size to the new screen model
+func (m *model) switchScreen(target Screen) {
+	m.currentScreen = target
+	// Pass current window size to new screen model to ensure proper initial rendering
+	sizeMsg := tea.WindowSizeMsg{Width: m.width, Height: m.height}
+	switch target {
+	case ScreenMenu:
+		m.menuModel, _ = m.menuModel.Update(sizeMsg)
+	case ScreenSingleElimination:
+		m.singleElimination, _ = m.singleElimination.Update(sizeMsg)
+	}
+}
+
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -37,7 +50,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "esc":
 			// Go back to menu from any screen
 			if m.currentScreen != ScreenMenu {
-				m.currentScreen = ScreenMenu
+				m.switchScreen(ScreenMenu)
 				return m, nil
 			}
 		}
@@ -46,15 +59,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 	case screenChangeMsg:
 		// Handle screen changes
-		m.currentScreen = msg.screen
-		// Pass current window size to new screen model
-		sizeMsg := tea.WindowSizeMsg{Width: m.width, Height: m.height}
-		switch msg.screen {
-		case ScreenMenu:
-			m.menuModel, _ = m.menuModel.Update(sizeMsg)
-		case ScreenSingleElimination:
-			m.singleElimination, _ = m.singleElimination.Update(sizeMsg)
-		}
+		m.switchScreen(msg.screen)
 		return m, nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -5,51 +5,24 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
+	"go-tournament/tournament"
 )
-
-type tournamentType struct {
-	name        string
-	description string
-	icon        string
-}
 
 type model struct {
-	tournaments []tournamentType
-	selected    int
-	width       int
-	height      int
+	currentScreen       Screen
+	menuModel           menuModel
+	singleElimination   tournament.SingleEliminationModel
+	width               int
+	height              int
 }
 
-var (
-	cardStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#874BFD")).
-			Padding(1, 2).
-			Width(25).
-			Height(8)
-
-	selectedCardStyle = cardStyle.Copy().
-				BorderForeground(lipgloss.Color("#FF69B4")).
-				Background(lipgloss.Color("#1A1A2E"))
-
-	titleStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("#FAFAFA")).
-			Align(lipgloss.Center).
-			MarginBottom(1)
-
-	headerStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("#FF6B6B")).
-			Align(lipgloss.Center).
-			MarginBottom(2)
-
-	helpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#626262")).
-			Align(lipgloss.Center).
-			MarginTop(2)
-)
+func newModel() model {
+	return model{
+		currentScreen:     ScreenMenu,
+		menuModel:         newMenuModel(),
+		singleElimination: tournament.NewSingleEliminationModel(),
+	}
+}
 
 func (m model) Init() tea.Cmd {
 	return nil
@@ -61,84 +34,48 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c", "q":
 			return m, tea.Quit
-		case "left", "h":
-			if m.selected > 0 {
-				m.selected--
+		case "esc":
+			// Go back to menu from any screen
+			if m.currentScreen != ScreenMenu {
+				m.currentScreen = ScreenMenu
+				return m, nil
 			}
-		case "right", "l":
-			if m.selected < len(m.tournaments)-1 {
-				m.selected++
-			}
-		case "enter":
-			return m, tea.Quit
 		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+	case screenChangeMsg:
+		// Handle screen changes
+		m.currentScreen = msg.screen
+		return m, nil
 	}
-	return m, nil
+
+	// Delegate to the appropriate screen model
+	var cmd tea.Cmd
+	switch m.currentScreen {
+	case ScreenMenu:
+		m.menuModel, cmd = m.menuModel.Update(msg)
+	case ScreenSingleElimination:
+		m.singleElimination, cmd = m.singleElimination.Update(msg)
+	}
+
+	return m, cmd
 }
 
 func (m model) View() string {
-	var cards []string
-
-	for i, tournament := range m.tournaments {
-		var style lipgloss.Style
-		if i == m.selected {
-			style = selectedCardStyle
-		} else {
-			style = cardStyle
-		}
-
-		content := fmt.Sprintf("%s\n\n%s\n\n%s",
-			tournament.icon,
-			titleStyle.Render(tournament.name),
-			tournament.description,
-		)
-
-		cards = append(cards, style.Render(content))
+	// Delegate to the appropriate screen view
+	switch m.currentScreen {
+	case ScreenMenu:
+		return m.menuModel.View()
+	case ScreenSingleElimination:
+		return m.singleElimination.View()
+	default:
+		return "Unknown screen"
 	}
-
-	cardsRow := lipgloss.JoinHorizontal(lipgloss.Center, cards...)
-
-	header := headerStyle.Render("🏆 Tournament Manager 🏆")
-	help := helpStyle.Render("← → or h l to navigate • Enter to select • q to quit")
-
-	content := lipgloss.JoinVertical(
-		lipgloss.Center,
-		header,
-		cardsRow,
-		help,
-	)
-
-	return lipgloss.Place(
-		m.width, m.height,
-		lipgloss.Center, lipgloss.Center,
-		content,
-	)
 }
 
 func main() {
-	m := model{
-		tournaments: []tournamentType{
-			{
-				name:        "Single Elimination",
-				description: "Classic bracket style\nwhere losers are\neliminated instantly",
-				icon:        "🥊",
-			},
-			{
-				name:        "Double Elimination",
-				description: "Players get a second\nchance in the\nloser's bracket",
-				icon:        "🔄",
-			},
-			{
-				name:        "Round Robin",
-				description: "Everyone plays\neveryone else\nat least once",
-				icon:        "🔁",
-			},
-		},
-		selected: 0,
-	}
+	m := newModel()
 
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {

--- a/main.go
+++ b/main.go
@@ -47,6 +47,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case screenChangeMsg:
 		// Handle screen changes
 		m.currentScreen = msg.screen
+		// Pass current window size to new screen model
+		sizeMsg := tea.WindowSizeMsg{Width: m.width, Height: m.height}
+		switch msg.screen {
+		case ScreenMenu:
+			m.menuModel, _ = m.menuModel.Update(sizeMsg)
+		case ScreenSingleElimination:
+			m.singleElimination, _ = m.singleElimination.Update(sizeMsg)
+		}
 		return m, nil
 	}
 

--- a/menu.go
+++ b/menu.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type tournamentType struct {
+	name        string
+	description string
+	icon        string
+	screen      Screen
+}
+
+type menuModel struct {
+	tournaments []tournamentType
+	selected    int
+	width       int
+	height      int
+}
+
+var (
+	cardStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#874BFD")).
+			Padding(1, 2).
+			Width(25).
+			Height(8)
+
+	selectedCardStyle = cardStyle.Copy().
+				BorderForeground(lipgloss.Color("#FF69B4")).
+				Background(lipgloss.Color("#1A1A2E"))
+
+	titleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FAFAFA")).
+			Align(lipgloss.Center).
+			MarginBottom(1)
+
+	headerStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FF6B6B")).
+			Align(lipgloss.Center).
+			MarginBottom(2)
+
+	helpStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#626262")).
+			Align(lipgloss.Center).
+			MarginTop(2)
+)
+
+func newMenuModel() menuModel {
+	return menuModel{
+		tournaments: []tournamentType{
+			{
+				name:        "Single Elimination",
+				description: "Classic bracket style\nwhere losers are\neliminated instantly",
+				icon:        "🥊",
+				screen:      ScreenSingleElimination,
+			},
+			{
+				name:        "Double Elimination",
+				description: "Players get a second\nchance in the\nloser's bracket",
+				icon:        "🔄",
+				screen:      ScreenDoubleElimination,
+			},
+			{
+				name:        "Round Robin",
+				description: "Everyone plays\neveryone else\nat least once",
+				icon:        "🔁",
+				screen:      ScreenRoundRobin,
+			},
+		},
+		selected: 0,
+	}
+}
+
+func (m menuModel) Init() tea.Cmd {
+	return nil
+}
+
+type screenChangeMsg struct {
+	screen Screen
+}
+
+func (m menuModel) Update(msg tea.Msg) (menuModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "left", "h":
+			if m.selected > 0 {
+				m.selected--
+			}
+		case "right", "l":
+			if m.selected < len(m.tournaments)-1 {
+				m.selected++
+			}
+		case "enter":
+			// Send message to switch screen
+			selectedScreen := m.tournaments[m.selected].screen
+			return m, func() tea.Msg {
+				return screenChangeMsg{screen: selectedScreen}
+			}
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	}
+	return m, nil
+}
+
+func (m menuModel) View() string {
+	var cards []string
+
+	for i, tournament := range m.tournaments {
+		var style lipgloss.Style
+		if i == m.selected {
+			style = selectedCardStyle
+		} else {
+			style = cardStyle
+		}
+
+		content := fmt.Sprintf("%s\n\n%s\n\n%s",
+			tournament.icon,
+			titleStyle.Render(tournament.name),
+			tournament.description,
+		)
+
+		cards = append(cards, style.Render(content))
+	}
+
+	cardsRow := lipgloss.JoinHorizontal(lipgloss.Center, cards...)
+
+	header := headerStyle.Render("🏆 Tournament Manager 🏆")
+	help := helpStyle.Render("← → or h l to navigate • Enter to select • q to quit")
+
+	content := lipgloss.JoinVertical(
+		lipgloss.Center,
+		header,
+		cardsRow,
+		help,
+	)
+
+	return lipgloss.Place(
+		m.width, m.height,
+		lipgloss.Center, lipgloss.Center,
+		content,
+	)
+}

--- a/screen.go
+++ b/screen.go
@@ -1,0 +1,11 @@
+package main
+
+// Screen represents different screens/states in the application
+type Screen int
+
+const (
+	ScreenMenu Screen = iota
+	ScreenSingleElimination
+	ScreenDoubleElimination
+	ScreenRoundRobin
+)

--- a/tournament/single_elimination.go
+++ b/tournament/single_elimination.go
@@ -1,0 +1,62 @@
+package tournament
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type SingleEliminationModel struct {
+	width  int
+	height int
+}
+
+var (
+	seHeaderStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FF6B6B")).
+			Align(lipgloss.Center).
+			MarginBottom(2)
+
+	seHelpStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#626262")).
+			Align(lipgloss.Center).
+			MarginTop(2)
+)
+
+func NewSingleEliminationModel() SingleEliminationModel {
+	return SingleEliminationModel{}
+}
+
+func (m SingleEliminationModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m SingleEliminationModel) Update(msg tea.Msg) (SingleEliminationModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	}
+	return m, nil
+}
+
+func (m SingleEliminationModel) View() string {
+	header := seHeaderStyle.Render("🥊 Single Elimination Tournament")
+	content := fmt.Sprintf("\n\nSingle Elimination Mode\n\nComing soon...\n\n")
+	help := seHelpStyle.Render("Press Esc to go back to menu")
+
+	view := lipgloss.JoinVertical(
+		lipgloss.Center,
+		header,
+		content,
+		help,
+	)
+
+	return lipgloss.Place(
+		m.width, m.height,
+		lipgloss.Center, lipgloss.Center,
+		view,
+	)
+}


### PR DESCRIPTION
Refactor monolithic app structure into modular, scalable architecture:

- Add screen state management system (screen.go)
- Extract menu logic into separate module (menu.go)
- Create tournament package structure (tournament/)
- Implement screen routing and delegation in main model
- Add ESC key to return to menu from any screen
- Support screen transitions via custom messages

This establishes foundation for adding tournament-specific functionality and enables seamless navigation between different screens.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 메인 메뉴 화면 추가: 카드형 토너먼트 선택, 좌우 이동 및 Enter로 진입, ESC로 메뉴 복귀
  - 단일 엘리미네이션 화면 초안 제공(헤더·콘텐츠 플레이스홀더·도움말 표시)

- 리팩터링
  - 화면 기반 구조로 전환하여 화면별 상태·렌더링 위임 및 UI 흐름 간소화

- 문서
  - README에 개발 단계(Phase 2 완료), 프로젝트 구조 및 개발 계획 링크 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->